### PR TITLE
Exibir mensagem no login

### DIFF
--- a/arquivos/cmc-profile.sh
+++ b/arquivos/cmc-profile.sh
@@ -1,0 +1,11 @@
+# /etc/profile.d/cmc-profile.sh - Exibe mensagem no login do usuario
+# Atencao: para ser exibido, o arquivo 'login.msg' deve ser diferente do
+# 'instant.msg'
+
+if [ "$(id -u)" -ne 0 ]; then
+	MSG="/mnt/suporte/login.msg"
+	if [ -f "$MSG" ]; then
+		/usr/local/cmc/scripts/instant.msg.sh "$MSG"
+	fi
+fi
+

--- a/arquivos/instant.msg.sh
+++ b/arquivos/instant.msg.sh
@@ -9,42 +9,47 @@
 # usuario se ela for deletada manualmente do /home
 # Verificar como corrigir isto.
 
-# Arquivo de mensagem remoto, no servidor
-MNT=/mnt/suporte/instant.msg
+# Arquivo de mensagem deve ser passado por parâmetro
+if [ -z "$1" ]; then
+  logger "[$0] Arquivo de mensagem esperado, mas nenhum fornecido."
+  exit 1
+fi
+MSG="$1"
 
 # Arquivo de mensagem local, copiado
-VAR=$HOME/.instant.msg
-ARQ=$VAR/instant.msg
+MSGDIR=$HOME/.instant.msg
+ARQ=$MSGDIR/instant.msg
 
-#Usuário logado
-WHO=$( who | grep 'tty' | cut -d ' ' -f 1 )
+# Usuário logado
+WHO=$( id | cut -d '(' -f 2 | cut -d ')' -f 1 )
+WHOSDISPLAY=$( who | grep "$WHO" | cut -d '(' -f 2 | cut -d ')' -f 1 )
 
 # Funcao para mostrar a mensagem na tela
 MostraMsg()
 {
-	if ! pgrep -f "zenity.*instant.msg" >/dev/null; then
-		if zenity --text-info --height=500 --width=500 --display=:0 --filename="$MNT" --title "Diretoria de Informática:" --checkbox="Estou ciente do aviso" 2>/dev/null; then
-			cp "$MNT" "$VAR"
-			logger "[$0] Mensagem exibida. Usuario ciente."
-		else
-			logger "[$0] Mensagem exibida. Usuario cancelou."
-		fi
-	fi
+  if ! pgrep -f "zenity.*instant.msg" >/dev/null; then
+    if zenity --text-info --height=500 --width=500 --display="$WHOSDISPLAY" --filename="$MSG" --title "Diretoria de Informática:" --checkbox="Estou ciente do aviso" 2>/dev/null; then
+      'cp' -u "$MSG" "$MSGDIR" # as plicas garantem que o comando cp seja executado independente de alias no bashrc
+      logger "[$0] Mensagem exibida. Usuario ciente."
+    else
+      logger "[$0] Mensagem exibida. Usuario cancelou."
+    fi
+  fi
 }
 
 if [ -z "$LOGNAME" ] || [ -z "$WHO" ]; then
-        exit 0;
+  exit 0;
 fi
 
 if [ "$WHO" != "$LOGNAME" ]; then
-        exit 0;
-elif [ -f "$MNT" ]; then
-  if [ ! -d "$VAR" ]; then
-    mkdir "$VAR"
+  exit 0;
+elif [ -f "$MSG" ]; then
+  if [ ! -d "$MSGDIR" ]; then
+    mkdir "$MSGDIR"
   fi
 
   if [ -f "$ARQ" ]; then
-    if ! diff "$MNT" "$ARQ" >/dev/null; then
+    if ! diff "$MSG" "$ARQ" >/dev/null; then
       MostraMsg &
     fi
   else

--- a/scripts/040-skel.sh
+++ b/scripts/040-skel.sh
@@ -222,7 +222,7 @@ echo 'if [ "$EUID" != "0" ] ; then
 	INSTANT="/usr/local/cmc/scripts/instant.msg.sh"
 	RESULT_I=$(crontab -l 2>/dev/null | grep -c "instant.msg.sh")
 	if [ $RESULT_I -eq 0 ]; then
-		echo "*/3 *     * * *   $INSTANT" > /tmp/$USER.cron;
+		echo "*/3 *     * * *   $INSTANT /mnt/suporte/instant.msg" > /tmp/$USER.cron;
 		crontab /tmp/$USER.cron
 	fi
 fi' >> /etc/skel/.profile
@@ -231,6 +231,5 @@ fi
 # Tecnicamente não skel, mas faz parte da msg instantânea
 mkdir -p /usr/local/cmc/scripts/
 cp ../arquivos/instant.msg.sh /usr/local/cmc/scripts/instant.msg.sh
-
-
+cp ../arquivos/cmc-profile.sh /etc/profile.d/cmc-profile.sh
 

--- a/scripts/999-arquivos-modificados.sh
+++ b/scripts/999-arquivos-modificados.sh
@@ -60,3 +60,6 @@ ln -sf /etc/cron.hourly/nssupdate.sh /usr/local/cmc/modificados/nssupdate.sh
 # Configura retencao do syslog e auth
 ln -sf /etc/logrotate.d/rsyslog /usr/local/cmc/modificados/rsyslog
 
+# Configura mensagem de login
+ln -sf /etc/profile.d/cmc-profile.sh /usr/local/cmc/modificados/cmc-profile.sh
+


### PR DESCRIPTION
Corrige o script instant.msg.sh para receber as mensagens por parâmetro e permitir a exibição de mensagens no login.
**Atencão:** para ser exibido, o arquivo `login.msg` deve ser diferente do `instant.msg`.