### PR TITLE
Update 060-autostart.sh

### DIFF
--- a/scripts/060-autostart.sh
+++ b/scripts/060-autostart.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Desabilita o autostart da mensagem de bem vinda, do update manager e mintreport
-mv /etc/xdg/autostart/mintupdate.desktop /etc/xdg/autostart/mintupdate.desktop.disable
-mv /etc/xdg/autostart/mintwelcome.desktop /etc/xdg/autostart/mintwelcome.desktop.disable
+#mv /etc/xdg/autostart/mintupdate.desktop /etc/xdg/autostart/mintupdate.desktop.disable
+#mv /etc/xdg/autostart/mintwelcome.desktop /etc/xdg/autostart/mintwelcome.desktop.disable
 mv /etc/xdg/autostart/mintreport.desktop /etc/xdg/autostart/mintreport.desktop.disable
 
 # Adiciona ao autostart o ownCloud e o Psi


### PR DESCRIPTION
Comentadas linhas referenciando "mintupdate" "mintwelcome" que interrompiam o script principal na instalação no Mint 19.3