### PR TITLE
Update 260-bloqueio-mate.sh

### DIFF
--- a/scripts/260-bloqueio-mate.sh
+++ b/scripts/260-bloqueio-mate.sh
@@ -3,14 +3,14 @@
 chmod 700 /usr/bin/mate-terminal
 
 #Remove execução do Mintupdate
-chmod 700 /usr/bin/mintupdate #update automatico
+#chmod 700 /usr/bin/mintupdate #update automatico
 
 # Remove execução do editor de permissões usuário dconf-editor
 #chmod 700 /usr/bin/dconf-editor #editor de permissões usuário
 # Não vem instalado por padrão
 
 # Remove execução do programa editor de itens do menu, menulibre
-chmod 700 /usr/bin/menulibre
+#chmod 700 /usr/bin/menulibre
 
 # Remove execução do editor de cada item do menu, mate-desktop-item-edit
 chmod 700 /usr/bin/mate-desktop-item-edit
@@ -27,7 +27,7 @@ chmod 700 /usr/bin/mate-network-properties
 # Cria uma ACL para que suporte possa abrir terminal
 setfacl -m u:suporte:rwx /usr/bin/mate-terminal
 setfacl -m g:dif:rx /usr/bin/mate-terminal
-setfacl -m g:dif:rx /usr/bin/menulibre
+#setfacl -m g:dif:rx /usr/bin/menulibre
 setfacl -m g:dif:rx /usr/bin/mate-desktop-item-edit
 setfacl -m g:dif:rx /usr/bin/nm-connection-editor
 setfacl -m g:dif:rx /usr/bin/ccsm


### PR DESCRIPTION
Comentadas linhas referenciando "mintupdate" "menulibre" que interrompiam o script principal na instalação no Mint 19.3