### PR TITLE
fix(yml): altera diretório favoritos gerenciados firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Todas as alterações significativas neste projeto serão documentadas aqui.
 O formato é baseado em [Keep a Changelog](http://keepachangelog.com/) e este
 projeto segue [Semantic Versioning](http://semver.org/).
 
+## 6.1.5
+
+### Fix
+
+Corrige diretório de favoritos gerenciáveis Firefox. Antes dependia da distribuição.
+
 ## 6.1.4
 
 ### Fix

--- a/roles/estacao/tasks/060-configura-browsers.yml
+++ b/roles/estacao/tasks/060-configura-browsers.yml
@@ -44,8 +44,8 @@
     # Referencia para policies do Firefox:
     # https://mozilla.github.io/policy-templates/
     # # https://mozilla.github.io/policy-templates/#managedbookmarks
-    - src: "policies-firefox.j2"
-      dest: "/usr/lib/firefox/distribution/policies.json"
+    - src: "policies.json"
+      dest: "/etc/firefox/policies"
     # Referencia para policies do Chrome:
     # https://cloud.google.com/docs/chrome-enterprise/policies/
     - src: "policies-google-chrome.j2"

--- a/roles/estacao/tasks/060-configura-browsers.yml
+++ b/roles/estacao/tasks/060-configura-browsers.yml
@@ -44,8 +44,8 @@
     # Referencia para policies do Firefox:
     # https://mozilla.github.io/policy-templates/
     # # https://mozilla.github.io/policy-templates/#managedbookmarks
-    - src: "policies.json"
-      dest: "/etc/firefox/policies"
+    - src: "policies-firefox.j2"
+      dest: "/etc/firefox/policies/policies.json"
     # Referencia para policies do Chrome:
     # https://cloud.google.com/docs/chrome-enterprise/policies/
     - src: "policies-google-chrome.j2"

--- a/roles/estacao/tasks/990-versionamento.yml
+++ b/roles/estacao/tasks/990-versionamento.yml
@@ -4,5 +4,5 @@
 - name: "Mantém versionamento"
   ansible.builtin.copy:
     dest: "{{ estacao_cmc_dir }}/version"
-    content: "ET-6.1.4"
+    content: "ET-6.1.5"
     mode: "0644"


### PR DESCRIPTION
# Descrição do Merge Request

Na task do Ansible **060-configura-browsers.yml**:

Altera diretório aonde ficarão as políticas do Firefox, já que os favoritos gerenciáveis estão bugados e sumindo em alguns PCs. 

### Observação

O repositório **iac-automacao** também possui scripts que configuram o browser, incluindo um de favoritos gerenciáveis.
Script: /iac-automacao/et-atualizacao/et/scripts/**instala-bookmarks.sh.j2**

Veja mais em:
https://github.com/CMCuritiba/iac-monorepo/issues/83

# Diretório de políticas do Firefox

Antes:
> /usr/lib/firefox/distribution/policies.json

Agora:  
> /etc/firefox/policies

favoritos gerenciados firefox em **role/estacao/tasks/060-configura-browsers.yml**

# O que há de novo?
- Alteração do diretório 
# O que mudou?
  - Local das políticas do Firefox para **/etc/firefox/policies/**

Resolves: #174 
See also: **

# Checklist

### Estacao-Trabalho-CMC

- [X] Eu rodei este código localmente
- [X] Eu escrevi os testes necessários
- [x] Eu utilizei _type-hints_ em meu código
- [X] Eu não deixei dados _hard-coded_ em meu código
- [x] Eu atualizei o CHANGELOG/README

### iac-automação

- [X] Eu criei uma branch (issue-174) e PR para o IAC-Automação 

**Recursos adicionais**

Link para qualquer recurso externo utilizado (issue, projeto, website, etc)

[Issue#174](https://github.com/CMCuritiba/Estacao-Trabalho-CMC/issues/174) - Maio 2025
[Issue#663](https://github.com/CMCuritiba/Estacao-Trabalho-CMC/issues/663) - Jan 2025

**Considerações adicionais**

- Há mais alguma coisa que se deve saber?
- Alguma observação sobre o deployment?
- Alguma documentação adicional?
