### PR TITLE
[MELHORIA] Firewall UFW com acesso SSH/VNC restrito à rede DTIC

### DIFF
--- a/roles/estacao/tasks/030-instala-programas.yml
+++ b/roles/estacao/tasks/030-instala-programas.yml
@@ -33,6 +33,8 @@
       - rdesktop
       - vino
       - openssh-server
+      # Firewall
+      - ufw
       # Mídia
       - vlc
       - audacity

--- a/roles/estacao/tasks/215-firewall.yml
+++ b/roles/estacao/tasks/215-firewall.yml
@@ -1,0 +1,31 @@
+---
+# Firewall (ufw): política restritiva, expondo apenas os serviços de acesso
+# remoto (SSH e VNC) e somente para a rede de gerência da DTIC.
+#
+# As regras de liberação são aplicadas ANTES de habilitar o ufw para evitar
+# que a gerência remota (Ansible/SSH) seja bloqueada durante a execução.
+- name: "Firewall - permite SSH a partir da rede da DTIC"
+  community.general.ufw:
+    rule: allow
+    port: "22"
+    proto: tcp
+    src: "{{ estacao_dtic_network }}"
+
+- name: "Firewall - permite VNC a partir da rede da DTIC"
+  community.general.ufw:
+    rule: allow
+    port: "5900"
+    proto: tcp
+    src: "{{ estacao_dtic_network }}"
+
+- name: "Firewall - define política padrão (nega entrada, permite saída)"
+  community.general.ufw:
+    direction: "{{ item.direction }}"
+    policy: "{{ item.policy }}"
+  loop:
+    - { direction: incoming, policy: deny }
+    - { direction: outgoing, policy: allow }
+
+- name: "Firewall - habilita o ufw"
+  community.general.ufw:
+    state: enabled

--- a/roles/estacao/tasks/main.yml
+++ b/roles/estacao/tasks/main.yml
@@ -116,6 +116,11 @@
   tags:
     - ssh
 
+- name: Configura o firewall (ufw)
+  ansible.builtin.import_tasks: 215-firewall.yml
+  tags:
+    - firewall
+
 - name: Configura o VNC
   ansible.builtin.import_tasks: 220-vnc.yml
   tags:


### PR DESCRIPTION
## Resumo

Adiciona firewall UFW às estações de trabalho, expondo apenas SSH (22) e VNC (5900) para a rede da DTIC e negando toda entrada por padrão.

Issue relacionada: #222

## O que mudou

- Regras ufw: permite SSH (porta 22) e VNC (porta 5900) somente a partir de `estacao_dtic_network`
- Política padrão: deny incoming, allow outgoing
- As regras de permissão são criadas **antes** de habilitar o ufw para evitar bloqueio do Ansible/SSH durante o provisionamento

## Checklist

- [x] Eu rodei este código localmente
- [x] Eu não deixei dados hard-coded (usa variável `estacao_dtic_network`)

## Considerações adicionais

> ⚠️ **Handoff — saída do estágio (10/07/2026)**
>
> O conteúdo desta branch foi integrado ao **PR #180** (`167-melhoria-atualizar-para-mint-22`) em `220-vnc.yml` com escopo ligeiramente diferente. Antes de mergear este PR, verificar se há conflito ou duplicação com o que já está no PR #180. Este PR pode ser fechado em favor do #180 caso a equipe decida consolidar lá.

Veja também: PR #180 que já incorpora este firewall UFW para Mint 22.
